### PR TITLE
Return injected keys from renderStatic

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function renderStatic(renderFn) {
   return {
     html: html,
     css: css,
+    injectedKeys: keys,
     hydrationSrc: generateHydrationScriptSrc(keys, css)
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ test('server rendering', function(t) {
 
   t.equal(result.html, 'html contents');
   t.equal(result.css, '.bar {}');
+  t.deepLooseEqual(result.injectedKeys, ['bar']);
   t.equal(result.hydrationSrc,
     ';try{(function(){window["__GLOBAL_STYLETRON_HYDRATE@1__"]=["bar"];var style=document.createElement("style");style.setAttribute("data-styletron","");style.appendChild(document.createTextNode(".bar {}"));(document.head||document.getElementsByTagName("head")[0]).appendChild(style);})();}catch(e){};');
   t.end();
@@ -28,6 +29,7 @@ test('reset before render', function(t) {
 
   t.equal(result.html, 'html contents');
   t.equal(result.css, '.bar > .foo {}');
+  t.deepLooseEqual(result.injectedKeys, ['bar']);
   t.equal(result.hydrationSrc,
     ';try{(function(){window["__GLOBAL_STYLETRON_HYDRATE@1__"]=["bar"];var style=document.createElement("style");style.setAttribute("data-styletron","");style.appendChild(document.createTextNode(".bar \\u003E .foo {}"));(document.head||document.getElementsByTagName("head")[0]).appendChild(style);})();}catch(e){};');
   t.end();


### PR DESCRIPTION
In the case where a CSP prevents inline scripts returning the injected keys as an array is useful to hydrate styletron on the client.
